### PR TITLE
Update README for 4.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here is my Nexus 4 LTE and LTE hotspot/tethering fix. This is different from oth
 
 
 ## Requirements
-Any **rooted 4.4.3 ROM with init.d support**, like CM, AOSPA, or modified stock and, of course, an LTE Band 4 AWS-enabled SIM and service provider.
+Any **rooted 4.4.3-4.4.4 ROM with init.d support**, like CM, AOSPA, or modified stock and, of course, an LTE Band 4 AWS-enabled SIM and service provider.
 
 
 ## Installation instructions


### PR DESCRIPTION
We're using "4.4.3-4.4.4" instead of "4.4.3-4" per the last 2 commits.

This appears to be the only other place where the package needs to be
updated for 4.4.4.
